### PR TITLE
Syntax improvement for views

### DIFF
--- a/lib/jsonify/json_value.rb
+++ b/lib/jsonify/json_value.rb
@@ -67,7 +67,7 @@ module Jsonify
     attr_accessor :key, :value
     def initialize(key, value=nil)
       @key = key.to_s
-      @value = Generate.value(value)
+      @value = Generate.value(value.respond_to?(@key) ? value.send(@key) : value)
     end
     def to_json
       %Q{#{key.to_json}:#{value.to_json}}


### PR DESCRIPTION
I made a small change to make views a little simpler.  If a value responds to its key, call that method on the value and use the returned data as the value instead.  This helps make the view code a little more DRY.  Here's a before and after comparison:

``` ruby
# Before
json.users @users do |u|
  json.id             u.id
  json.username       u.username
  json.first_name     u.first_name
  json.last_name      u.last_name
end

# After
json.users @users do |u|
  json.id             u
  json.username       u
  json.first_name     u
  json.last_name      u
end
```
