### PR TITLE
Extracted Jsonify::Builder#array!

### DIFF
--- a/lib/jsonify/builder.rb
+++ b/lib/jsonify/builder.rb
@@ -96,6 +96,47 @@ module Jsonify
       end
       self
     end
+    
+    # Creates array of json objects in current element from array passed to this method.
+    # Accepts block which yields each array element. 
+    #
+    # @example Create array in root JSON element
+    #     json.array!(@links) do |link|
+    #       json.rel link.first
+    #       json.href link.last
+    #     end
+    # 
+    # @example compiles to something like ...
+    #     [
+    #        {
+    #          "rel": "self",
+    #          "href": "http://example.com/people/123"
+    #        },
+    #        {
+    #          "rel": "school",
+    #          "href": "http://gatech.edu"
+    #        }
+    #     ]
+    #
+    def array!(args)
+      __array
+      args.each do |arg|
+        @level += 1
+        yield arg
+        @level -= 1
+                
+        value = @stack.pop
+      
+        # If the object created was an array with a single value
+        # assume that just the value should be added
+        if (JsonArray === value && value.values.length <= 1)
+          value = value.values.first
+        end
+      
+        @stack[@level].add value
+      end
+    end
+    
 
     # Adds a new JsonPair to the builder where the key of the pair is set to the method name
     # (`sym`).
@@ -153,22 +194,7 @@ module Jsonify
       if args.nil?
         block.call
       else
-        __array
-        args.each do |arg|
-          @level += 1
-          block.call(arg)
-          @level -= 1
-          
-          value = @stack.pop
-
-          # If the object created was an array with a single value
-          # assume that just the value should be added
-          if (JsonArray === value && value.values.length <= 1)
-            value = value.values.first
-          end
-
-          @stack[@level].add value
-        end
+        array!(args, &block)
       end
 
       # Set the value on the pair to the object at the top of the stack

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -332,6 +332,21 @@ PRETTY_JSON
       expected = '{"letters":["A","B","C"]}'
       MultiJson.load(json.compile!).should == MultiJson.load(expected)
     end
-    
+
+  end
+
+  describe 'array!' do
+    it 'allow creating array from root' do
+      json.array!([1, 2, 3]) do |number|
+        json.id number
+        json.times2 number * 2
+      end
+
+      MultiJson.load(json.compile!).should == [
+        {'id' => 1, 'times2' => 2},
+        {'id' => 2, 'times2' => 4},
+        {'id' => 3, 'times2' => 6},
+      ]
+    end
   end
 end


### PR DESCRIPTION
It's often required to start json response with an array, something that would create this:

``` json
[
  {"id": 1, "name": "John"},
  {"id": 2, "name": "Peter"}
]
```

This patch allows doing it like this:

``` ruby
json.array!(@people) do |person|
  json.id person.id
  json.name person.name
end
```
