### PR TITLE
Added Jsonify::Builder#attributes!

### DIFF
--- a/lib/jsonify/builder.rb
+++ b/lib/jsonify/builder.rb
@@ -55,8 +55,18 @@ module Jsonify
     def tag!(sym, args=nil, &block)
       method_missing(sym, *args, &block)
     end
-    
-    # Compiles the JSON objects into a string representation. 
+
+    # Adds a new JsonPair for each attribute in attrs by taking attr as key and value of that attribute in object.
+    #
+    # @param object [Object] Object to take values from
+    # @param *attrs [Array<Symbol>] Array of attributes for JsonPair keys
+    def attributes!(object, *attrs)
+      attrs.each do |attr|
+        method_missing attr, object.send(attr)
+      end
+    end
+
+    # Compiles the JSON objects into a string representation.
     # If initialized with +:verify => true+, the compiled result will be verified by attempting to re-parse it using +MultiJson.load+.
     # If initialized with +:format => :pretty+, the compiled result will be parsed and encoded via +MultiJson.dump(<json>, :pretty => true)+
     # This method can be called without any side effects. You can call +compile!+ at any time, and multiple times if desired.

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -148,7 +148,7 @@ PRETTY_JSON
 
   describe "attributes!" do
     it "should allow create object with attributes of another object" do
-      object = stub(id: 1, name: 'foo')
+      object = stub(:id => 1, :name => 'foo')
       json.attributes!(object, :id, :name)
       MultiJson.load(json.compile!).should == {'id' => 1, 'name' => 'foo'}
     end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -145,7 +145,15 @@ PRETTY_JSON
       MultiJson.load(json.compile!).should ==  MultiJson.load('{"1":[2,3],"4":5}')
     end
   end
-  
+
+  describe "attributes!" do
+    it "should allow create object with attributes of another object" do
+      object = stub(id: 1, name: 'foo')
+      json.attributes!(object, :id, :name)
+      MultiJson.load(json.compile!).should == {'id' => 1, 'name' => 'foo'}
+    end
+  end
+
   describe 'using blocks' do
 
     it 'should allow names with spaces using tag!' do


### PR DESCRIPTION
It's very common to write templates like this:

``` ruby
json.id @user.id
json.name @user.name
# ...
```

This patch allows shortening that and write something like this instead:

``` ruby
json.attributes! @user, :id, :name
```
