### PR TITLE
Fixes for tests to run under rspec3

### DIFF
--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -148,7 +148,7 @@ PRETTY_JSON
 
   describe "attributes!" do
     it "should allow create object with attributes of another object" do
-      object = stub(:id => 1, :name => 'foo')
+      object = double(:id => 1, :name => 'foo')
       json.attributes!(object, :id, :name)
       MultiJson.load(json.compile!).should == {'id' => 1, 'name' => 'foo'}
     end

--- a/spec/jsonify_spec.rb
+++ b/spec/jsonify_spec.rb
@@ -1,4 +1,4 @@
 require 'spec_helper'
 describe Jsonify do
-  it('should be true') {true.should be_true}
+  it('should be true') {expect(true).to be true}
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,5 @@ require 'jsonify'
 require 'jsonify/tilt'
 
 RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end


### PR DESCRIPTION
Hi there.  I made some patches for jsonify's tests to run correctly under rspec3, which is the default in Debian unstable now and I thought you might like to apply them if you are considering any further development.

Regards,

Tim.
